### PR TITLE
Enable continue button for dao group proposals

### DIFF
--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/ReviewProposal/ReviewProposal.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/ReviewProposal/ReviewProposal.tsx
@@ -38,6 +38,7 @@ import { getEntityById } from 'redux/entities/entities.selectors'
 import { useAppSelector } from 'redux/hooks'
 import { useTheme } from 'styled-components'
 import { useWallet } from 'wallet-connector'
+import { Flex } from '@mantine/core'
 
 const ReviewProposal: React.FC = () => {
   const theme: any = useTheme()
@@ -334,7 +335,7 @@ const ReviewProposal: React.FC = () => {
       search.append('selectedTemplateEntityId', selectedTemplateEntityId)
     }
     navigate({
-      pathname: `/entity/${entityId}/dashboard/governance/${coreAddress}/page`,
+      pathname: `/entity/${entityId}/dashboard/governance/${coreAddress}/create/actions`,
       search: search.toString(),
     })
   }
@@ -380,121 +381,114 @@ const ReviewProposal: React.FC = () => {
   }
 
   return (
-    <FlexBox width='100%' $gap={10} $alignItems='stretch'>
+    <Flex w='100%' gap={10} align={'stretch'}>
       {/* Card */}
-      <FlexBox
-        $direction='column'
-        width='100%'
-        $gap={4}
-        p={6}
-        border={`1px solid ${theme.ixoNewBlue}`}
-        $borderRadius='8px'
+      <Flex
+        direction='column'
+        w='100%'
+        gap={16}
+        p={24}
+        style={{ border: `1px solid ${theme.ixoNewBlue}`, borderRadius: '8px' }}
       >
         {/* Header */}
         {daoGroup?.type && (
-          <FlexBox border={`1px solid ${theme.ixoDarkBlue}`} $borderRadius='100px' p={1.5}>
+          <Flex style={{ border: `1px solid ${theme.ixoDarkBlue}`, borderRadius: '100px' }} p={6}>
             <Typography color='blue' size='md' transform='capitalize'>
               {daoGroup.type}
             </Typography>
-          </FlexBox>
+          </Flex>
         )}
 
-        <FlexBox>
+        <Flex>
           <Typography variant='secondary' size='2xl'>
             {profile?.name}
           </Typography>
-        </FlexBox>
+        </Flex>
 
-        <FlexBox width='100%' $gap={3.5} $alignItems='center' mb={4}>
+        <Flex w='100%' gap={3.5} align={'center'} mb={4}>
           <SvgBox $svgHeight={5} color={theme.ixoDarkestBlue}>
             <img src='/assets/images/eco/wait.svg' />
           </SvgBox>
           <ProgressBar total={0} approved={0} rejected={0} height={20} />
-        </FlexBox>
+        </Flex>
 
-        <FlexBox $direction='column' $gap={1}>
+        <Flex direction={'column'} gap={4}>
           <Typography size='sm'>Proposed by</Typography>
           <Typography weight='bold'>{truncateString(signer.address, 20)}</Typography>
-        </FlexBox>
+        </Flex>
 
-        <FlexBox width='100%' $gap={4}>
-          <FlexBox $direction='column' $flexBasis='50%' $gap={1}>
+        <Flex w='100%' gap={16}>
+          <Flex direction={'column'} style={{ flexBasis: '50%' }} gap={4}>
             <Typography size='sm'>Submission Date</Typography>
             <Typography weight='bold'>{moment.utc(new Date()).format('YYYY-MM-DD [at] HH:mm [UTC]')}</Typography>
-          </FlexBox>
-          <FlexBox $direction='column' $flexBasis='50%' $gap={1}>
+          </Flex>
+          <Flex direction={'column'} style={{ flexBasis: '50%' }} gap={4}>
             <Typography size='sm'>Closes</Typography>
             <Typography weight='bold'>
               {moment.utc(new Date().getTime() + votingPeriod * 1000).format('YYYY-MM-DD [at] HH:mm [UTC]')}
             </Typography>
-          </FlexBox>
-        </FlexBox>
+          </Flex>
+        </Flex>
 
-        <FlexBox width='100%' $gap={4}>
-          <FlexBox $direction='column' $flexBasis='50%' $gap={1}>
+        <Flex w='100%' gap={16}>
+          <Flex direction={'column'} style={{ flexBasis: '50%' }} gap={4}>
             <Typography size='sm'>Linked Resources</Typography>
-            <FlexBox $gap={3}>
+            <Flex gap={12}>
               {Object.values(linkedResourceData)
                 .filter((item) => !!item)
                 .map((item: any) => {
                   const { id, type } = item
                   const Icon = EntityLinkedResourceConfig[type].icon
                   return (
-                    <SvgBox
+                    <Flex
                       key={id}
-                      width='35px'
-                      height='35px'
-                      $alignItems='center'
-                      $justifyContent='center'
-                      border={`1px solid ${theme.ixoNewBlue}`}
-                      $borderRadius='4px'
-                      $svgWidth={5}
-                      $svgHeight={5}
-                      color={theme.ixoNewBlue}
-                      cursor='pointer'
+                      w='35px'
+                      h='35px'
+                      align={'center'}
+                      justify={'center'}
+                      style={{ border: `1px solid ${theme.ixoNewBlue}`, borderRadius: '4px', cursor: 'pointer' }}
                       onClick={() => setSelectedLinkedResource(item)}
                     >
-                      <img src={Icon} alt='replaced' />
-                    </SvgBox>
+                      <SvgBox $svgWidth={5} $svgHeight={5} color={theme.ixoNewBlue}>
+                        <img src={Icon} alt='replaced' />
+                      </SvgBox>
+                    </Flex>
                   )
                 })}
-            </FlexBox>
-          </FlexBox>
-          <FlexBox $direction='column' $flexBasis='50%' $gap={1}>
+            </Flex>
+          </Flex>
+          <Flex direction={'column'} style={{ flexBasis: '50%' }} gap={4}>
             <Typography size='sm'>Actions</Typography>
-            <FlexBox $gap={3}>
+            <Flex gap={12}>
               {validActions
                 .filter((action) => ProposalActionConfig[action.group].items[action.text])
                 .map((action) => {
                   const Icon = ProposalActionConfig[action.group].items[action.text].icon
                   return (
-                    <SvgBox
+                    <Flex
                       key={action.id}
-                      width='35px'
-                      height='35px'
-                      $alignItems='center'
-                      $justifyContent='center'
-                      border={`1px solid ${theme.ixoNewBlue}`}
-                      $borderRadius='4px'
-                      $svgWidth={5}
-                      $svgHeight={5}
-                      color={theme.ixoNewBlue}
-                      cursor='pointer'
+                      w='35px'
+                      h='35px'
+                      align={'center'}
+                      justify={'center'}
+                      style={{ border: `1px solid ${theme.ixoNewBlue}`, borderRadius: '4px', cursor: 'pointer' }}
                       onClick={() => setSelectedAction(action)}
                     >
-                      <img src={Icon} alt='replaced' />
-                    </SvgBox>
+                      <SvgBox $svgWidth={5} $svgHeight={5} color={theme.ixoNewBlue}>
+                        <img src={Icon} alt='replaced' />
+                      </SvgBox>
+                    </Flex>
                   )
                 })}
-            </FlexBox>
-          </FlexBox>
-        </FlexBox>
-      </FlexBox>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
       {/* Text */}
-      <FlexBox $direction='column' height='100%' $justifyContent='space-between' $gap={4} style={{ flex: '0 0 400px' }}>
+      <Flex direction='column' h='100%' justify={'space-between'} gap={16} style={{ flex: '0 0 400px' }}>
         {!success && (
           <>
-            <FlexBox $direction='column' width='100%' $gap={4}>
+            <Flex direction={'column'} w='100%' gap={16}>
               <Typography variant='secondary'>
                 This is the last step before submitting this governance proposal for {profile?.name}.
               </Typography>
@@ -506,28 +500,28 @@ const ReviewProposal: React.FC = () => {
               <Typography variant='secondary'>
                 When you are ready to commit, sign with your DID Account keys.
               </Typography>
-            </FlexBox>
+            </Flex>
             {/* Actions */}
-            <FlexBox width='100%' $gap={4}>
+            <Flex w='100%' gap={4}>
               <Button variant='secondary' onClick={handleBack} style={{ width: '100%' }}>
                 Back
               </Button>
               <Button variant='primary' onClick={handleSubmit} style={{ width: '100%' }} loading={submitting}>
                 Sign To Submit
               </Button>
-            </FlexBox>
+            </Flex>
           </>
         )}
         {success === 'true' && (
           <>
-            <FlexBox
-              $direction='column'
-              $justifyContent='center'
-              $alignItems='center'
-              width='100%'
-              height='100%'
-              $gap={4}
-              $textAlign='center'
+            <Flex
+              direction='column'
+              justify={'center'}
+              align={'center'}
+              w='100%'
+              h='100%'
+              gap={16}
+              style={{ textAlign: 'center' }}
             >
               <SvgBox color={theme.ixoLightGreen} $svgWidth={30} $svgHeight={30}>
                 <img src='/assets/images/icon-check-circle.svg' />
@@ -535,42 +529,35 @@ const ReviewProposal: React.FC = () => {
               <Typography variant='secondary' size='2xl'>
                 {profile?.name} Successfully created!
               </Typography>
-            </FlexBox>
-            <FlexBox width='100%' $gap={4}>
+            </Flex>
+            <Flex w='100%' gap={4}>
               <Button variant='primary' onClick={handleNext} style={{ width: '100%' }}>
                 View in the Dashboard
               </Button>
-            </FlexBox>
+            </Flex>
           </>
         )}
         {success === 'false' && (
           <>
-            <FlexBox
-              $direction='column'
-              $justifyContent='center'
-              $alignItems='center'
-              width='100%'
-              height='100%'
-              $gap={4}
-            >
+            <Flex direction='column' justify={'center'} align={'center'} w='100%' h='100%' gap={16}>
               <SvgBox color={theme.ixoDarkOrange} $svgWidth={30} $svgHeight={30}>
                 <img src='/assets/images/icon-exclamation-circle.svg' />
               </SvgBox>
               <Typography variant='secondary' size='2xl'>
                 Something went wrong. Please try again.
               </Typography>
-            </FlexBox>
-            <FlexBox width='100%' $gap={4}>
+            </Flex>
+            <Flex w='100%' gap={4}>
               <Button variant='secondary' onClick={() => navigate(-1)} style={{ width: '100%' }}>
                 Back
               </Button>
               <Button variant='primary' onClick={handleSubmit} style={{ width: '100%' }} loading={submitting}>
                 Sign To Submit
               </Button>
-            </FlexBox>
+            </Flex>
           </>
         )}
-      </FlexBox>
+      </Flex>
 
       {SetupActionModal && (
         <SetupActionModal
@@ -587,7 +574,7 @@ const ReviewProposal: React.FC = () => {
           onClose={(): void => setSelectedLinkedResource(undefined)}
         />
       )}
-    </FlexBox>
+    </Flex>
   )
 }
 

--- a/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
+++ b/src/screens/CurrentEntity/Dashboard/DAODashboard/Governance/CreateProposal/SetupProposalActions/SetupActions.tsx
@@ -1,7 +1,7 @@
-import { FlexBox } from 'components/CoreEntry/App.styles'
+import { Flex } from '@mantine/core'
 import { Typography } from 'components/Typography'
 import { useCreateEntityState } from 'hooks/createEntity'
-import { Button } from 'screens/CreateEntity/Components'
+import { Button } from 'pages/CreateEntity/Components'
 import React, { useMemo } from 'react'
 import { SetupActionsForm } from './SetupActionsForm'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -12,32 +12,29 @@ const SetupActions: React.FC = () => {
   const { proposal, updateProposal } = useCreateEntityState()
 
   const actions = useMemo(() => proposal?.actions ?? [], [proposal])
-  const validActions = useMemo(() => actions.filter((item) => item.data), [actions])
 
   const handleBack = () => {
-    navigate(`/entity/${entityId}/dashboard/governance/${coreAddress}/info`)
+    navigate(`/entity/${entityId}/dashboard/governance/${coreAddress}/create/setup`)
   }
   const handleContinue = () => {
-    navigate(`/entity/${entityId}/dashboard/governance/${coreAddress}/page`)
+    navigate(`/entity/${entityId}/dashboard/governance/${coreAddress}/create/review`)
   }
 
   return (
-    <FlexBox width={'100%'} $direction='column' $gap={15} $justifyContent='center'>
+    <Flex w={'100%'} direction='column' gap={32} justify={'center'}>
       <Typography variant='secondary' size='2xl'>
-        The following {validActions.length} actions get executed when the proposal passes.
+        Create new proposal
       </Typography>
 
       <SetupActionsForm actions={actions} setActions={(actions) => updateProposal({ ...proposal, actions })} />
 
-      <FlexBox width='100%' $justifyContent='flex-start' $gap={4}>
+      <Flex w='100%' justify={'flex-start'} gap={4}>
         <Button variant='secondary' onClick={handleBack}>
           Back
         </Button>
-        <Button onClick={handleContinue} disabled={validActions.length === 0}>
-          Continue
-        </Button>
-      </FlexBox>
-    </FlexBox>
+        <Button onClick={handleContinue}>Continue</Button>
+      </Flex>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
## Scope
This PR addresses an issue where the "Continue" button was disabled on DAO Group proposal creation when no actions were specified. It also refines the navigation flow and updates UI components for consistency.

## Work Done
*   Enabled the "Continue" button on the "Setup Proposal Actions" page, allowing users to proceed even without adding actions.
*   Corrected the navigation paths for "Back" and "Continue" buttons across the proposal creation flow (`SetupActions.tsx` and `ReviewProposal.tsx`) to ensure a logical user journey.
*   Replaced custom `FlexBox` components with `@mantine/core`'s `Flex` component for improved UI consistency and maintainability.

## Steps to Test
1.  Navigate to the DAO Group proposal creation flow.
2.  Proceed to the "Setup Actions" step.
3.  Verify that the "Continue" button is enabled even if no actions are added.
4.  Click "Continue" and then "Back" to ensure correct navigation between "Setup Actions" and "Review Proposal".
5.  On the "Setup Actions" page, click "Back" to ensure correct navigation to "Setup Proposal".

## Screenshots
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-e6e82c9c-5a74-4e64-a5f5-84fe1ebae24c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6e82c9c-5a74-4e64-a5f5-84fe1ebae24c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

